### PR TITLE
Remove Tagset checks in ModifiedDistanceExt

### DIFF
--- a/IRBTModUtils/IRBTModUtils/Feature/MovementMods.cs
+++ b/IRBTModUtils/IRBTModUtils/Feature/MovementMods.cs
@@ -17,13 +17,6 @@ namespace IRBTModUtils.Feature
         {
             if (mech == null) { return 0f; }
 
-            TagSet mechTags = mech.GetTags();
-            if (mechTags.Contains(ModTags.ImmobileUnit))
-            {
-                Mod.Log.Debug?.Write($"Mech: {mech.DistinctId()} has tag: '{ModTags.ImmobileUnit}', returning 0 movement.");
-                return 0;
-            }
-
             bool isImmobile = mech.StatCollection.GetValue<bool>(ModStats.ImmobileUnit);
             if (isImmobile)
             {

--- a/IRBTModUtils/IRBTModUtils/Feature/MovementMods.cs
+++ b/IRBTModUtils/IRBTModUtils/Feature/MovementMods.cs
@@ -13,6 +13,25 @@ namespace IRBTModUtils.Feature
             ModState.ExtMovementMods.Sort((x, y) => x.Priority.CompareTo(y.Priority));
         }
 
+        public static bool IsImmobile(AbstractActor actor)
+        {
+            Statistic statistic;
+            return actor.StatCollection.stats.TryGetValue(ModStats.ImmobileUnit, out statistic) && statistic.Value<bool>();
+        }
+
+        public static void SetImmobile(AbstractActor actor, bool value)
+        {
+            Statistic statistic;
+            if (actor.StatCollection.stats.TryGetValue(ModStats.ImmobileUnit, out statistic))
+            {
+                statistic.SetValue(value);
+            }
+            else
+            {
+                actor.StatCollection.AddStatistic(ModStats.ImmobileUnit, value);
+            }
+        }
+
         internal static float ModifiedDistanceExt(this Mech mech, bool skipExternalAll, bool isRun = false, params string[] extensionsToSkip)
         {
             if (mech == null) { return 0f; }

--- a/IRBTModUtils/IRBTModUtils/IRBTModUtils.csproj
+++ b/IRBTModUtils/IRBTModUtils/IRBTModUtils.csproj
@@ -26,8 +26,8 @@
     <AssemblyTitle>IRBTModUtils</AssemblyTitle>
     <Product>IRBTModUtils</Product>
     <Copyright>Copyright © 2023</Copyright>
-    <AssemblyVersion>2.0.2.0</AssemblyVersion>
-    <FileVersion>2.0.2.0</FileVersion>
+    <AssemblyVersion>2.0.3.0</AssemblyVersion>
+    <FileVersion>2.0.3.0</FileVersion>
     <LangVersion>11</LangVersion>
     
     <!-- Necessary for the Xoshiro random code -->

--- a/IRBTModUtils/IRBTModUtils/Patches/MechPatches.cs
+++ b/IRBTModUtils/IRBTModUtils/Patches/MechPatches.cs
@@ -64,8 +64,10 @@ namespace IRBTModUtils.Patches
         {
             Mod.Log.Trace?.Write("M:I entered.");
 
+            var immobileValue = __instance.GetTags().Contains(ModTags.ImmobileUnit);
+
             // Initialize mod-specific statistics
-            __instance.StatCollection.AddStatistic<bool>(ModStats.ImmobileUnit, false);
+            __instance.StatCollection.AddStatistic<bool>(ModStats.ImmobileUnit, immobileValue);
         }
     }
 }


### PR DESCRIPTION
GetTags() is expensive because it creates a new tagSet and then merges in another tagSet into it before its returned. Contains on a tagSet is also relatively expensive.

There is already a stat version of the ImmobileUnit tag that exists and is checked for in this same method. when this stat is initialized, it now checks for the tag on the unit to correctly set the stats default value, removing the need to check for the tag later.

This improves AI performance.